### PR TITLE
Add "Louis Dionne: A system for resource deadlock prevention"

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,32 +5,32 @@
 * [Jeff Garland:Library in a Week: C++11 & Boost Cookbook (I)](https://github.com/boostcon/cppnow_presentations_2013/blob/master/mon/2013_library_in_a_week_day1.pdf?raw=true)
 * Daniel Quinlan: Keynote: C++ Use in High Performance Computing Within DOE: Past and Future
 * [Rob Stewart: Survey of Multi-Threaded Programming Support in C++11 and Boost](https://github.com/boostcon/cppnow_presentations_2013/blob/master/mon/mt_survey.pdf?raw=true)
-* Thiago Macieira: Qt event loop, networking and I/O API	
+* Thiago Macieira: Qt event loop, networking and I/O API
 * [Boris Schäling: Containers in Boost](https://github.com/boostcon/cppnow_presentations_2013/blob/master/mon/containers_in_boost.pdf?raw=true)
-* Tony Van Eerd: Low Level Threading with C++11	
+* Tony Van Eerd: Low Level Threading with C++11
 * [Leor Zolman: A Zephyr Overview of C++11](https://github.com/boostcon/cppnow_presentations_2013/blob/master/mon/zephyr_cpp_overview.pdf?raw=true)
 * [Eric Niebler: A First Look at Proto-0x](https://github.com/boostcon/cppnow_presentations_2013/blob/master/mon/proto-v5-preview.pdf?raw=true) | [PPTX Format](https://github.com/boostcon/cppnow_presentations_2013/blob/master/mon/proto-v5-preview.pptx?raw=true)
-* Tony Van Eerd: Non-Allocating std::future/promise	
+* Tony Van Eerd: Non-Allocating std::future/promise
 * [Ábel Sinkovics: Boosting MPL with Haskell elements](https://github.com/boostcon/cppnow_presentations_2013/blob/master/mon/boosting_mpl_with_haskell_elements.pdf?raw=true)
 
 ## Tuesday
 
 * Jeff Garland: Library in a Week: C++11 & Boost Cookbook (II)
 * [Chandler Carruth: Keynote: Optimizing the Emergent Structures of C++](https://github.com/boostcon/cppnow_presentations_2013/blob/master/tue/cppnow_2013keynote.pdf?raw=true)
-* Scott Schurr: Sweating the Small Stuff: Brace Initialization, Unions and Enums	
+* Scott Schurr: Sweating the Small Stuff: Brace Initialization, Unions and Enums
 * [David Sankel: The Intellectual Ascent to Agda](https://github.com/boostcon/cppnow_presentations_2013/blob/master/tue/intellectual_ascent_to_agda.pdf?raw=true) [pptx](https://github.com/boostcon/cppnow_presentations_2013/blob/master/tue/intellectual_ascent_to_agda.pptx?raw=true)
 * [Hartmut Kaiser, Vinay Amatya: HPX: A C++ Standards Compliant Runtime System For Asynchronous Parallel And Distributed Computing](https://github.com/boostcon/cppnow_presentations_2013/blob/master/tue/managing_asynchrony_in_cpp.pdf?raw=true)
 * [Edouard Alligand: Scaling with C++11](https://github.com/boostcon/cppnow_presentations_2013/blob/master/tue/scaling_with_cpp11.pdf?raw=true)
-* Phil Miller, Laxmikant Kale, Ramprasad Venkataraman: Parallel Programming using Charm++	
+* Phil Miller, Laxmikant Kale, Ramprasad Venkataraman: Parallel Programming using Charm++
 * [John Bandela: Easy Binary Compatible C++ Interfaces Across Compilers](https://github.com/boostcon/cppnow_presentations_2013/blob/master/tue/easy_binary_compat.pdf?raw=true) | [PPT Format](https://github.com/boostcon/cppnow_presentations_2013/blob/master/tue/easy_binary_compat.ppt?raw=true)
-* Michael Wong: Transactional Memory in C++	
+* Michael Wong: Transactional Memory in C++
 * [Dominik Charousset, Matthias Vallentin: libcppa – Designing an Actor Semantic for C++11](https://github.com/boostcon/cppnow_presentations_2013/blob/master/tue/cppnow13-libcppa.pdf?raw=true)
 * Thiago Macieira: Binary compatibility for library developers
 
 ## Wednesday
 * Jeff Garland: Library in a Week: C++11 & Boost Cookbook (III)
 * [Stanley Lippman: Keynote: yet another paradigm shift – A Meta4 model of concurrency](https://github.com/boostcon/cppnow_presentations_2013/blob/master/wed/yaps_cppnow_2013.pdf?raw=true) | [pptx Format](https://github.com/boostcon/cppnow_presentations_2013/blob/master/wed/yaps_cppnow_2013.pptx?raw=true)
-* Joel de Guzman: Inside Spirit X3: Redesigning Boost.Spirit for C++11	
+* Joel de Guzman: Inside Spirit X3: Redesigning Boost.Spirit for C++11
 * [Larisse Voufo: Weak Hiding for C++ Concepts: via a Framework for Reasoning about Name Binding in Programming Languages](https://github.com/boostcon/cppnow_presentations_2013/blob/master/wed/weak_hiding.pdf?raw=true) | [PPTX Format](https://github.com/boostcon/cppnow_presentations_2013/blob/master/wed/weak_hiding.pptx?raw=true)
 * Thiago Macieira: C++11 use in Qt5: Challanges and Solutions
 * [Richard Saunders: Thread-safe and Thread-neutral Bags](https://github.com/boostcon/cppnow_presentations_2013/blob/master/wed/ThreadSafeBagsConf.pdf?raw=true)
@@ -43,25 +43,25 @@
 
 ## Thursday
 * Jeff Garland: Library in a Week: C++11 & Boost Cookbook (IV)
-* Alex Fabijanic: Dynamic C++	
+* Alex Fabijanic: Dynamic C++
 * [David Sankel: DeBruijn Bind: A more powerful bind that retains its simplicity](https://github.com/boostcon/cppnow_presentations_2013/blob/master/thu/DeBruijn_Bind.pdf?raw=true) | [PPTX Format](https://github.com/boostcon/cppnow_presentations_2013/blob/master/thu/DeBruijn_Bind.pptx?raw=true)
 * Rob Stewart: Multi-Threading With C++11 and Boost
-* Andrew Sutton: Concepts Lite: Constraining Templates with Predicates	
-* Alex Fabijanic: Look ma, “update DB to HTML5 using C++”, no hands!	
+* Andrew Sutton: Concepts Lite: Constraining Templates with Predicates
+* Alex Fabijanic: Look ma, “update DB to HTML5 using C++”, no hands!
 * [Boris Kolpackov: ODB, an ORM for C++(11)](https://github.com/boostcon/cppnow_presentations_2013/blob/master/thu/odb-orm-cxx11.pdf?raw=true)
-* Alisdair Meredith: Allocators in C++11	
-* Boris Schäling: Boost.Graph for Beginners	
+* Alisdair Meredith: Allocators in C++11
+* Boris Schäling: Boost.Graph for Beginners
 * [Marshall Clow: Fun with Tuples](https://github.com/boostcon/cppnow_presentations_2013/blob/master/thu/fun_with_tuples.pdf?raw=true)
-* Michael Caisse: Solving World Problems with Fusion	
-* Sumant Tambe: Standardizing the Data Distribution Service (DDS) API for Modern C++	
+* Michael Caisse: Solving World Problems with Fusion
+* Sumant Tambe: Standardizing the Data Distribution Service (DDS) API for Modern C++
 * [Sebastian Redl: Overloading the Member Access Operator](https://github.com/boostcon/cppnow_presentations_2013/blob/master/thu/overloading_dot.pdf?raw=true)
-* Vassil Vassilev: Interactive, Introspected C++ at CERN	
-* Bryce Adelstein-Lelbach: Boost.Asio and Boost.Serialization: Design Patterns for Object Transmission	
+* Vassil Vassilev: Interactive, Introspected C++ at CERN
+* Bryce Adelstein-Lelbach: Boost.Asio and Boost.Serialization: Design Patterns for Object Transmission
 * Zoltan Porkolab: Debugging and Profiling C++ Template Metaprograms
 
 ## Friday
 * Jeff Garland: Library in a Week: C++11 & Boost Cookbook (V)
-* Richard Saunders, Clinton Jeffery: Dynamic, Recursive, Heterogeneous Types in Statically-Typed Languages	
-* Julian Storer: The Projucer: Live coding with C++ and the LLVM JIT engine	
+* Richard Saunders, Clinton Jeffery: Dynamic, Recursive, Heterogeneous Types in Statically-Typed Languages
+* Julian Storer: The Projucer: Live coding with C++ and the LLVM JIT engine
 * Bart Janssens: Building finite-element matrix expressions with Boost Proto and the Eigen library
-* Louis Dionne: A system for resource deadlock prevention using intrusive dynamic analysis
+* [Louis Dionne: A system for resource deadlock prevention using intrusive dynamic analysis](http://ldionne.github.io/d2-cppnow-2013)


### PR DESCRIPTION
I added a link to my presentation in the README. As a side effect, my editor removed trailing white spaces.
